### PR TITLE
Allow (srfi 64)/(chibi test); and extend comparison predicates.

### DIFF
--- a/chibi-test.scm
+++ b/chibi-test.scm
@@ -1,4 +1,8 @@
-(import (scheme base) (scheme char) (srfi-152))
+(import (except (scheme base)
+                string=? string<? string>? string<=? string>=?)
+        (except (scheme char)
+                string-ci=? string-ci<? string-ci>? string-ci<=? string-ci>=?)
+        (srfi-152))
 
 (cond-expand
   ((library (chibi test))
@@ -164,6 +168,14 @@
 
 
 )
+
+(test-group "srfi-152:extended-comparisons"
+  (test "base cases for extended string comparisons"
+    '(#t #t #t #t #t #t #t #t #t #t)
+    (map (lambda (f) (and (f) (f "foo")))
+         (list string=? string<? string>? string<=? string>=?
+               string-ci=? string-ci<? string-ci>? string-ci<=? string-ci>=?))))
+
 (test-group "srfi-152:gauche:comparison"
 (test "string=?" #t (string=? "foo" "foo"))
 

--- a/chibi-test.scm
+++ b/chibi-test.scm
@@ -1,4 +1,19 @@
-(import (scheme base) (scheme char) (chibi test) (srfi-152))
+(import (scheme base) (scheme char) (srfi-152))
+
+(cond-expand
+  ((library (chibi test))
+   (import (chibi test)))
+  ((library (srfi 64))
+   (import (srfi 64))
+   (define-syntax test
+     (syntax-rules ()
+       ((_ arg ...) (test-equal arg ...))))
+   (define-syntax test-exit
+     (syntax-rules ()
+       ((_) (test-end))))
+   (test-begin "srfi-152 top"))
+  (else
+   (error "no suitable test framework available")))
 
 (define (complement proc) (lambda (x) (not (proc x))))
 (define (char-newline? ch) (eqv? ch #\newline))

--- a/chicken-test.scm
+++ b/chicken-test.scm
@@ -149,6 +149,14 @@
 
 
 )
+
+(test-group "srfi-152:extended-comparisons"
+  (test "base cases for extended string comparisons"
+    '(#t #t #t #t #t #t #t #t #t #t)
+    (map (lambda (f) (and (f) (f "foo")))
+         (list string=? string<? string>? string<=? string>=?
+               string-ci=? string-ci<? string-ci>? string-ci<=? string-ci>=?))))
+
 (test-group "srfi-152:gauche:comparison"
 (test "string=?" #t (string=? "foo" "foo"))
 

--- a/extend-comparisons.scm
+++ b/extend-comparisons.scm
@@ -1,0 +1,30 @@
+;;; Extend comparisons to 0 and 1 arguments.
+;; 2017-10-04 Sudarshan S Chawathe <chaw@eip10.org>
+
+;; For each (name . base-name) pair in arguments, define name to be
+;; comparison procedure similar to base-name, but allow it to accept 0
+;; or 1 arguments in addition to more (as permitted by base-name),
+;; returning true in the former cases.
+(define-syntax define-comparison/base/pairs
+  (syntax-rules ()
+    ((_ (name . base-name) ...)
+     (begin
+       (define (name . strs)
+         (or (null? strs)
+             (null? (cdr strs))
+             (apply base-name strs))) ...))))
+
+;; Extend the usual string comparison procedures as above.
+(define-comparison/base/pairs
+  (string=? . base-string=?)
+  (string<? . base-string<?)
+  (string>? . base-string>?)
+  (string<=? . base-string<=?)
+  (string>=? . base-string>=?)
+  (string-ci=? . base-string-ci=?)
+  (string-ci<? . base-string-ci<?)
+  (string-ci>? . base-string-ci>?)
+  (string-ci<=? . base-string-ci<=?)
+  (string-ci>=? . base-string-ci>=?))
+
+;;;

--- a/srfi-152.scm
+++ b/srfi-152.scm
@@ -3,8 +3,18 @@
 (module srfi-152 ()
 
   ;; R5RS+ procedures must not be imported, as we redefine them
-  (import (except scheme string->list string-copy string-fill!))
-
+  (import (rename (except scheme
+                          string->list string-copy string-fill!)
+                  (string=? base-string=?)
+                  (string<? base-string<?)
+                  (string>? base-string>?)
+                  (string<=? base-string<=?)
+                  (string>=? base-string>=?)
+                  (string-ci=? base-string-ci=?)
+                  (string-ci<? base-string-ci<?)
+                  (string-ci>? base-string-ci>?)
+                  (string-ci<=? base-string-ci<=?)
+                  (string-ci>=? base-string-ci>=?)))
   (import (only chicken include error use case-lambda
                         open-input-string open-output-string get-output-string))
 
@@ -16,7 +26,9 @@
                string-set!)
 
   ;; Export R5RS+ procedures
-  (export string->list string-copy string-fill!)
+  (export string->list string-copy string-fill!
+          string=? string<? string>? string<=? string>=?
+          string-ci=? string-ci<? string-ci>? string-ci<=? string-ci>=? )
 
   ;; Export R7RS procedures (defined in r7rs-shim file and chicken module)
   (import (only extras read-string))
@@ -47,5 +59,6 @@
 
   (include "macros.scm")
   (include "portable.scm")
+  (include "extend-comparisons.scm")
   (include "r7rs-shim.scm")
 )

--- a/srfi-152.sld
+++ b/srfi-152.sld
@@ -2,12 +2,22 @@
 
 (define-library (srfi-152)
 
-  (import (scheme base))
-  (import (scheme char))
+  (import (rename (scheme base)
+                  (string=? base-string=?)
+                  (string<? base-string<?)
+                  (string>? base-string>?)
+                  (string<=? base-string<=?)
+                  (string>=? base-string>=?))
+          (rename (scheme char)
+                  (string-ci=? base-string-ci=?)
+                  (string-ci<? base-string-ci<?)
+                  (string-ci>? base-string-ci>?)
+                  (string-ci<=? base-string-ci<=?)
+                  (string-ci>=? base-string-ci>=?)))
   (import (scheme cxr))
   (import (scheme case-lambda))
 
-  ;; Don't export R7RS procedures
+  ;; Don't export most R7RS procedures
   #;(no-export string? make-string string
                string->vector string->list list->string vector->string
                string-length string-ref substring string-copy
@@ -17,6 +27,10 @@
                string-append string-map string-for-each
                read-string write-string
                string-set! string-fill! string-copy!)
+
+  ;; but export comparison predicates extended to 0 and 1 arguments:
+  (export string=? string<? string>? string<=? string>=?
+          string-ci=? string-ci<? string-ci>? string-ci<=? string-ci>=?)
 
   ;; Remaining exports, grouped as in the SRFI
   (export string-null? string-every string-any)
@@ -42,4 +56,5 @@
 
   (include "macros.scm")
   (include "portable.scm")
+  (include "extend-comparisons.scm")
 )

--- a/utf8-chicken-test.scm
+++ b/utf8-chicken-test.scm
@@ -64,7 +64,7 @@
       (string-join '("foo" "bar" "baz") ";" 'suffix))
 )
 (test-group "srfi-152:gauche:selectors"
-(test "substring" "cde" (substring "abcde" 2))
+(test "substring" "cde" (substring "abcde" 2 5))
 (test "substring" "cd"  (substring "abcde" 2 4))
 (test "string-copy!" "abCDEfg"
        (let ((x (string-copy "abcdefg")))
@@ -336,9 +336,9 @@
 (test-group "srfi-152:gauche:replisplit"
 
 (test "string-replicate" "cdefab"
-       (string-replicate "abcdef" 2))
+       (string-replicate "abcdef" 2 8))
 (test "string-replicate" "efabcd"
-       (string-replicate "abcdef" -2))
+       (string-replicate "abcdef" -2 4))
 (test "string-replicate" "abcabca"
        (string-replicate "abc" 0 7))
 ;; (test "string-replicate" "abcabca"

--- a/utf8-chicken-test.scm
+++ b/utf8-chicken-test.scm
@@ -149,6 +149,14 @@
 
 
 )
+
+(test-group "srfi-152:extended-comparisons"
+  (test "base cases for extended string comparisons"
+    '(#t #t #t #t #t #t #t #t #t #t)
+    (map (lambda (f) (and (f) (f "foo")))
+         (list string=? string<? string>? string<=? string>=?
+               string-ci=? string-ci<? string-ci>? string-ci<=? string-ci>=?))))
+
 (test-group "srfi-152:gauche:comparison"
 (test "string=?" #t (string=? "foo" "foo"))
 

--- a/utf8-srfi-152.scm
+++ b/utf8-srfi-152.scm
@@ -3,9 +3,21 @@
 (module utf8-srfi-152 ()
 
   ;; R5RS+ and utf8 procedures must not be imported, as we redefine them
-  (import (except scheme
-     string-length string-ref string-set! make-string string substring
-     string-copy string->list list->string string-fill!))
+  (import (rename (except scheme
+                          string-length string-ref string-set! make-string string substring
+                          string-copy string->list list->string string-fill!)
+                  (string=? base-string=?)
+                  (string<? base-string<?)
+                  (string>? base-string>?)
+                  (string<=? base-string<=?)
+                  (string>=? base-string>=?)
+                  (string-ci=? base-string-ci=?)
+                  (string-ci<? base-string-ci<?)
+                  (string-ci>? base-string-ci>?)
+                  (string-ci<=? base-string-ci<=?)
+                  (string-ci>=? base-string-ci>=?)))
+  (import (only chicken include error use case-lambda
+                        open-input-string open-output-string get-output-string))
 
   (import (only chicken include error use case-lambda
                         open-input-string open-output-string get-output-string))
@@ -23,7 +35,9 @@
               string-set!)
 
   ;; Export R5RS+ procedures
-  (export string->list string-copy string-fill!)
+  (export string->list string-copy string-fill!
+          string=? string<? string>? string<=? string>=?
+          string-ci=? string-ci<? string-ci>? string-ci<=? string-ci>=? )
 
   ;; Export R7RS procedures (defined in r7rs-shim file and chicken module)
   (import (only utf8 read-string))
@@ -54,5 +68,6 @@
 
   (include "macros.scm")
   (include "portable.scm")
+  (include "extend-comparisons.scm")
   (include "r7rs-shim.scm")
 )


### PR DESCRIPTION
Add a cond-expand to allow chibi-test.scm to work on systems, such as
Kawa, that provide (srfi 64) for testing instead of (chibi test).